### PR TITLE
LAB01-03 : Some fix on instructions

### DIFF
--- a/Instructions/Exercises/01-use-prebuilt-models.md
+++ b/Instructions/Exercises/01-use-prebuilt-models.md
@@ -138,7 +138,6 @@ Now you're ready to use the SDK to evaluate the pdf file.
 
     ```csharp
     AnalyzeDocumentOperation operation = await client.AnalyzeDocumentFromUriAsync(WaitUntil.Completed, "prebuilt-invoice", fileUri);
-    await operation.WaitForCompletionAsync();
     ```
 
     **Python**

--- a/Instructions/Exercises/01-use-prebuilt-models.md
+++ b/Instructions/Exercises/01-use-prebuilt-models.md
@@ -36,10 +36,11 @@ Let's start by using the **Azure AI Document Intelligence Studio** and the Read 
 
     ![Screenshot showing the Read page in Azure AI Document Intelligence Studio.](../media/read-german-sample.png#lightbox)
 
+1. At the top-left, select **Analyze options**, then enable the **Language** check-box (under **Optional detection**) in the **Analyze options** pane and click on **Save**. 
 1. At the top-left, select **Run Analysis**.
 1. When the analysis is complete, the text extracted from the image is shown on the right in the **Content** tab. Review this text and compare it to the text in the original image for accuracy.
 1. Select the **Result** tab. This tab displays the extracted JSON code. 
-1. Scroll to the bottom of the JSON code in the **Result** tab. Notice that the read model has detected the language of each span. Most spans are in German (language code `de`) but the last span is in English (language code `en`).
+1. Scroll to the bottom of the JSON code in the **Result** tab. Notice that the read model has detected the language of each span. Most spans are in German (language code `de`) but you can find other language codes in the spans (e.g. English - language code `en` - in one of the last span).
 
     ![Screenshot showing the detection of language for two spans in the results from the read model in Azure AI Document Intelligence Studio.](../media/language-detection.png#lightbox)
 

--- a/Instructions/Exercises/01-use-prebuilt-models.md
+++ b/Instructions/Exercises/01-use-prebuilt-models.md
@@ -32,7 +32,7 @@ Let's start by using the **Azure AI Document Intelligence Studio** and the Read 
 1. Under **Document Analysis**, select the **Read** tile.
 1. If you are asked to sign into your account, use your Azure credentials.
 1. If you are asked which Azure AI Document Intelligence resource to use, select the subscription and resource name you used when you created the Azure AI Document Intelligence resource.
-1. In the list of documents on the left, select **read-german.png**.
+1. In the list of documents on the left, select **read-german.pdf**.
 
     ![Screenshot showing the Read page in Azure AI Document Intelligence Studio.](../media/read-german-sample.png#lightbox)
 

--- a/Instructions/Exercises/03-composed-model.md
+++ b/Instructions/Exercises/03-composed-model.md
@@ -62,14 +62,14 @@ Now, let's label the fields in the example forms:
 
 1. In the **Label data** page, in the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **FirstName** and then press *Enter*.
-1. In the document, select **John** and then select **FirstName**.
-1. In the top-right of the page, select **+**, and then select **Field**.
+1. Select the document called **f1040_1.pdf** on the left list, select **John** and then select **FirstName**.
+1. In the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **LastName** and then press *Enter*.
 1. In the document, select **Doe** and then select **LastName**.
-1. In the top-right of the page, select **+**, and then select **Field**.
+1. In the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **City** and then press *Enter*.
 1. In the document, select **Los Angeles** and then select **City**.
-1. In the top-right of the page, select **+**, and then select **Field**.
+1. In the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **State** and then press *Enter*.
 1. In the document, select **CA** and then select **State**.
 1. Repeat the labeling process for the remaining forms in the list on the left, using the labels you created. Label the same four fields: *FirstName*, *LastName*, *City*, and *State*.
@@ -108,16 +108,16 @@ Now, you must create a second model, which you'll train on example 1099 tax form
 
 Now, label the example forms with some fields:
 
-1. In the **Label data** page, in the top-right of the page, select **+**, and then select **Field**.
+1. In the **Label data** page, in the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **FirstName** and then press *Enter*.
-1. In the document, select **John** and then select **FirstName**.
-1. In the top-right of the page, select **+**, and then select **Field**.
+1. Select the document called **f1099msc_payer.pdf**, select **John** and then select **FirstName**.
+1. In the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **LastName** and then press *Enter*.
 1. In the document, select **Doe** and then select **LastName**.
-1. In the top-right of the page, select **+**, and then select **Field**.
+1. In the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **City** and then press *Enter*.
 1. In the document, select **New Haven** and then select **City**.
-1. In the top-right of the page, select **+**, and then select **Field**.
+1. In the top-right of the page, select **+ Add a field**, and then select **Field**.
 1. Type **State** and then press *Enter*.
 1. In the document, select **CT** and then select **State**.
 1. Repeat the labeling process for the remaining forms in the list on the left. Label the same four fields: *FirstName*, *LastName*, *City*, and *State*.


### PR DESCRIPTION
LAB01:
- The name of the file to use for test is a pdf not a png.
- The language options must be enabled in the Analyse option, otherwise there is no indication of the language in the result.
- Optimization in the code (C#).

LAB03:
- I added the name of the documents to use for the first labeling because the order of the training documents can be different from the alphabetical order in the labeling tool.
- Add the full name of the butto to add a new field instead the simple **+**.