### PR TITLE
LAB02-EX03-STEP12: The script to run the setup.cmd is wrong

### DIFF
--- a/Instructions/Exercises/02-custom-document-intelligence.md
+++ b/Instructions/Exercises/02-custom-document-intelligence.md
@@ -97,11 +97,7 @@ Then **save** your changes.
 1. In the terminal for the **Labfiles/02-custom-document-intelligence** folder, enter the following command to run the script:
 
     ```PowerShell
-    $currentdir=(Get-Item .).FullName
-    cd ..
     ./setup.cmd
-    cd $currentdir
-
     ```
 
 1. When the script completes, review the displayed output.


### PR DESCRIPTION
LAB02-EX03-STEP12: 
This pull request includes a small change to the `Instructions/Exercises/02-custom-document-intelligence.md` file. The change simplifies the instructions by removing unnecessary commands to navigate directories before and after running the script. The setup command is in the folder opened in the terminal while the script move to the ancestor folder before run the command (and the student receive an error because the script in not there).